### PR TITLE
remove pry-byebug test dependency as it breaks ci build: 

### DIFF
--- a/gdor-indexer.gemspec
+++ b/gdor-indexer.gemspec
@@ -40,5 +40,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'jettywrapper'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'pry-byebug'
 end


### PR DESCRIPTION
jenkins has:

"Gem::InstallError: byebug requires Ruby version >= 2.0.0."

so I just took it out.  

@cbeer 