### PR TITLE
Fix pub year fields

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,10 +18,10 @@ end
 #  sh 'irb -rubygems -I lib  -r ./frda_indexer.rb'
 # end
 
-task default: [:ci, :rubocop]
+task default: :ci
 
-desc 'run continuous integration suite (tests, coverage, docs)'
-task ci: [:rspec, :doc, :rubocop]
+desc 'run continuous integration suite'
+task ci: [:rspec, :rubocop]
 
 task spec: :rspec
 

--- a/gdor-indexer.gemspec
+++ b/gdor-indexer.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = GDor::Indexer::VERSION
   spec.authors       = ['Naomi Dushay', 'Laney McGlohon', 'Chris Beer']
   spec.email         = ['cabeer@stanford.edu']
-  spec.summary       = 'Gryphondor Solr indexing logic'
+  spec.summary       = 'PURL doc =>  Solr hash logic'
   spec.homepage      = 'https://github.com/sul-dlss/gdor-indexer'
   spec.license       = 'Apache 2'
 
@@ -35,10 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'equivalent-xml', '~> 0.5'
-  spec.add_development_dependency 'capybara'
-  spec.add_development_dependency 'poltergeist', '>= 1.5.0'
   spec.add_development_dependency 'vcr'
-  spec.add_development_dependency 'jettywrapper'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'pry-byebug'
 end

--- a/spec/unit/indexer_spec.rb
+++ b/spec/unit/indexer_spec.rb
@@ -120,14 +120,14 @@ describe GDor::Indexer do
       @indexer.index collection
     end
 
-    it 'indexs other resources as items' do
+    it 'indexes other resources as items' do
       expect(@indexer).to receive(:item_solr_document).with(resource)
       @indexer.index resource
     end
   end
 
   describe '#index_with_exception_handling' do
-    it 'capture,s log, and re-raise any exception thrown by the indexing process' do
+    it 'captures log and re-raises any exception thrown by the indexing process' do
       expect(@indexer).to receive(:index).with(resource).and_raise 'xyz'
       expect(@indexer.logger).to receive(:error)
       expect { @indexer.index_with_exception_handling(resource) }.to raise_error RuntimeError
@@ -433,7 +433,7 @@ describe GDor::Indexer do
   end
 
   # context "skip heartbeat" do
-  #   it "allows me to use a fake url for dor-fetcher-client" do
+  #   it "allows use of a fake url for dor-fetcher-client" do
   #     expect {GDor::Indexer.new(@config_yml_path)}.not_to raise_error
   #   end
   # end

--- a/spec/unit/mods_pub_fields_spec.rb
+++ b/spec/unit/mods_pub_fields_spec.rb
@@ -33,6 +33,47 @@ describe GDor::Indexer::ModsFields do
       end
     end
 
+    context 'pub_date (to know current behavior)' do
+      it 'calls Stanford::Mods::Record instance pub_date_sortable_string(false)' do
+        expect(sdb.smods_rec).to receive(:pub_date_facet)
+        sdb.doc_hash_from_mods[:pub_date]
+      end
+      it 'includes approx dates' do
+        m = mods_origin_info_start_str +
+              "<dateIssued qualifier='approximate'>1945</dateIssued>" +
+            mods_origin_info_end_str
+        sdb = sdb_for_mods(m)
+        expect(sdb.doc_hash_from_mods[:pub_date]).to eq('1945')
+      end
+      it 'takes single dateCreated' do
+        m = mods_origin_info_start_str +
+              "<dateCreated>1904</dateCreated>" +
+            mods_origin_info_end_str
+        sdb = sdb_for_mods(m)
+        expect(sdb.doc_hash_from_mods[:pub_date]).to eq('1904')
+      end
+      it_behaves_like 'expected', :pub_date, 'blah blah 1945 blah', '1945'
+      it_behaves_like 'expected', :pub_date, '1945', '1945'
+      it_behaves_like 'expected', :pub_date, '945', '945'
+      it_behaves_like 'expected', :pub_date, '66', nil
+      it_behaves_like 'expected', :pub_date, '5', nil
+      it_behaves_like 'expected', :pub_date, '0', nil
+      it_behaves_like 'expected', :pub_date, '-4', nil
+      it_behaves_like 'expected', :pub_date, '-15', nil
+      it_behaves_like 'expected', :pub_date, '-666', '666' # WRONG
+      it_behaves_like 'expected', :pub_date, '16--', nil
+      it_behaves_like 'expected', :pub_date, '8--', nil
+      it_behaves_like 'expected', :pub_date, '19th century', '19th century'
+      it_behaves_like 'expected', :pub_date, '9th century', '9th century'
+      it_behaves_like 'expected', :pub_date, '300 B.C.', '300 B.C.'
+      it_behaves_like 'expected', :pub_date, 'Text dated June 4, 1594; miniatures added by 1596', '1594'
+      it_behaves_like 'expected', :pub_date, 'Aug. 3rd, 1886', '1886'
+      it_behaves_like 'expected', :pub_date, 'Aug. 3rd, [18]86?', '1886'
+      it_behaves_like 'expected', :pub_date, 'early 1890s', '1890'
+      it_behaves_like 'expected', :pub_date, '1865-6', '1865'
+
+    end
+
     context 'pub_date_sort' do
       it 'calls Stanford::Mods::Record instance pub_date_sortable_string(false)' do
         expect(sdb.smods_rec).to receive(:pub_date_sortable_string).with(false)

--- a/spec/unit/mods_pub_fields_spec.rb
+++ b/spec/unit/mods_pub_fields_spec.rb
@@ -77,6 +77,7 @@ describe GDor::Indexer::ModsFields do
     context 'pub_date_sort' do
       it 'calls Stanford::Mods::Record instance pub_date_sortable_string(false)' do
         expect(sdb.smods_rec).to receive(:pub_date_sortable_string).with(false)
+        allow(sdb.smods_rec).to receive(:pub_date_sortable_string).with(true) # for pub_year_no_approx_isi
         sdb.doc_hash_from_mods[:pub_date_sort]
       end
       it 'includes approx dates' do
@@ -119,30 +120,36 @@ describe GDor::Indexer::ModsFields do
       end
       it 'pub_year_no_approx_isi calls Stanford::Mods::Record instance pub_date_facet_single_value(true)' do
         sdb = sdb_for_mods(mods)
-        expect(sdb.smods_rec).to receive(:pub_date_facet_single_value).with(true).and_call_original
-        allow(sdb.smods_rec).to receive(:pub_date_facet_single_value).with(false) # for other flavor
+        expect(sdb.smods_rec).to receive(:pub_date_sortable_string).with(true).and_call_original
+        allow(sdb.smods_rec).to receive(:pub_date_sortable_string).with(false) # for other flavor
         expect(sdb.doc_hash_from_mods[:pub_year_no_approx_isi]).to eq '2000'
       end
       it 'pub_year_w_approx_isi calls Stanford::Mods::Record instance pub_date_facet_single_value(false)' do
         sdb = sdb_for_mods(mods)
-        expect(sdb.smods_rec).to receive(:pub_date_facet_single_value).with(false).and_call_original
-        allow(sdb.smods_rec).to receive(:pub_date_facet_single_value).with(true) # for other flavor
+        expect(sdb.smods_rec).to receive(:pub_date_sortable_string).with(false).and_call_original
+        allow(sdb.smods_rec).to receive(:pub_date_sortable_string).with(true) # for other flavor
         expect(sdb.doc_hash_from_mods[:pub_year_w_approx_isi]).to eq '1500'
       end
       RSpec.shared_examples "single pub year facet" do |field_sym|
+        it_behaves_like 'expected', field_sym, 'blah blah 1945 blah', '1945'
         it_behaves_like 'expected', field_sym, '1945', '1945'
         it_behaves_like 'expected', field_sym, '945', '945'
         it_behaves_like 'expected', field_sym, '66', '66'
         it_behaves_like 'expected', field_sym, '5', '5'
         it_behaves_like 'expected', field_sym, '0', '0'
-        it_behaves_like 'expected', field_sym, '-4', '4 B.C.'
-        it_behaves_like 'expected', field_sym, '-15', '15 B.C.'
-        it_behaves_like 'expected', field_sym, '-666', '666 B.C.'
-        it_behaves_like 'expected', field_sym, '16--', '17th century'
-        it_behaves_like 'expected', field_sym, '8--', '9th century'
-        it_behaves_like 'expected', field_sym, '19th century', '19th century'
-        it_behaves_like 'expected', field_sym, '9th century', '9th century'
-        it_behaves_like 'expected', field_sym, '300 B.C.', '300 B.C.'
+        it_behaves_like 'expected', field_sym, '-4', '-4'
+        it_behaves_like 'expected', field_sym, '-15', '-15'
+        it_behaves_like 'expected', field_sym, '-666', '-666'
+        it_behaves_like 'expected', field_sym, '16--', '1600'
+        it_behaves_like 'expected', field_sym, '8--', '800'
+        it_behaves_like 'expected', field_sym, '19th century', '1800'
+        it_behaves_like 'expected', field_sym, '9th century', '800'
+        it_behaves_like 'expected', field_sym, '300 B.C.', '-300'
+        it_behaves_like 'expected', field_sym, 'Text dated June 4, 1594; miniatures added by 1596', '1594'
+        it_behaves_like 'expected', field_sym, 'Aug. 3rd, 1886', '1886'
+        it_behaves_like 'expected', field_sym, 'Aug. 3rd, [18]86?', '1886'
+        it_behaves_like 'expected', field_sym, 'early 1890s', '1890'
+        it_behaves_like 'expected', field_sym, '1865-6', '1865'
       end
       it_behaves_like "single pub year facet", :pub_year_no_approx_isi
       it_behaves_like "single pub year facet", :pub_year_w_approx_isi
@@ -154,6 +161,7 @@ describe GDor::Indexer::ModsFields do
       # FIXME:  it should be using a method approp for date slider values, not single value
       it 'pub_year_tisim calls Stanford::Mods::Record instance pub_date_sortable_string(false)' do
         expect(sdb.smods_rec).to receive(:pub_date_sortable_string).with(false)
+        allow(sdb.smods_rec).to receive(:pub_date_sortable_string).with(true) # for pub_year_no_approx_isi
         sdb.doc_hash_from_mods[:pub_year_tisim]
       end
       it 'includes approx dates' do


### PR DESCRIPTION
since "19th century" isn't actually an integer.  Nor is "300 B.C.".