### PR TITLE
Require newer version of stanford-mods

### DIFF
--- a/gdor-indexer.gemspec
+++ b/gdor-indexer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'harvestdor-indexer'
-  spec.add_dependency 'stanford-mods', '>= 1.4.0' # for new pub date methods
+  spec.add_dependency 'stanford-mods', '~> 2.2.1'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'rsolr'
   spec.add_dependency 'activesupport'


### PR DESCRIPTION
We will then release a bumped version of this gem so downstream
consumers can actually get what they want (geo features, mainly).